### PR TITLE
Prevent HTML pages being set as images

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const change = (start = 0) => {
         .then(url => download(url, path))
         .then(() => getType(path))
         .then(type => new Promise((resolve, reject) => {
-            if (!type && !config.types.includes(type.ext)) {
+            if (!type || !config.types.includes(type.ext)) {
                 reject('type is null');
                 return;
             }
@@ -42,10 +42,9 @@ const change = (start = 0) => {
         .then(() => wallpaper.set(name))
         .then(() => console.log('success!'))
         .catch(error => {
-            console.error(error)
-            change(start + 1)
+            console.error(error);
+            change(start + 1);
         });
-    }
 };
 
 const getURL = obj => new Promise((resolve, reject) => {


### PR DESCRIPTION
For some reason Lines 45, 46 and 48 weren't working for me. Fixed them.

Main issue seems to be line 33 where you're using an AND instead of OR. So it's saying:
`if type is null and type isn't an extension` but we can't get the type's extension because it's null. So we do `!type ||` so that when type is null, it immediately executes that statement instead of checking the extension. 

Looks like that should do the trick 🆗 